### PR TITLE
LIBDRS-9361: populate queue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ LOG_FILE_BACKUP_COUNT=10
 # for local development, the log file will be written to the current directory
 LOGFILE_PATH=/app/logs
 # if set to true, file logging will be turned off
-CONSOLE_LOGGING_ONLY=false 
+CONSOLE_LOGGING_ONLY=false
 
 BATCH_SIZE=1000
 

--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,8 @@ DB_PORT=
 DB_NAME=
 DB_USER=
 DB_PASSWORD=
+
+# paths for judaica.py and ocflpaths.py 
+JUDAICA_PATH=/home/drsadm/bin/judaica.py
+OCFLPATHS_PATH=/home/drsadm/bin/ocflpaths.py
+DELAY_SECS=5

--- a/drs2/__init__.py
+++ b/drs2/__init__.py
@@ -25,7 +25,7 @@ def configure_logger():  # pragma: no cover
     logger = logging.getLogger('drs2_judaica_update')
     logger.addHandler(console_handler)
     # Defaults to console logging
-    if os.getenv("CONSOLE_LOGGING_ONLY", "true") == "false":
+    if ((os.getenv("CONSOLE_LOGGING_ONLY", "true")).strip()) == "false":
         file_handler = TimedRotatingFileHandler(
             filename=f"{log_file_path}/{container_id}_console_{timestamp}.log",
             when=LOG_ROTATION,

--- a/drs2/__init__.py
+++ b/drs2/__init__.py
@@ -14,7 +14,7 @@ timestamp = datetime.today().strftime('%Y-%m-%d')
 def configure_logger():  # pragma: no cover
     log_level = os.getenv("APP_LOG_LEVEL", "WARNING")
     log_file_path = os.getenv("LOGFILE_PATH",
-                              "./logs/drs2_judaica_update")
+                              "/app/logs/drs2_judaica_update")
     formatter = logging.Formatter(
                 '%(asctime)s - %(name)s - %(levelname)s - ' +
                 '[%(filename)s:%(funcName)s:%(lineno)d] - %(message)s')

--- a/drs2/drsdb.py
+++ b/drs2/drsdb.py
@@ -95,3 +95,18 @@ class DrsDB:
             path = row[0]
             storage_class = row[1]
         return path, storage_class
+
+    def check_object_in_update_queue(self, object_id):
+        """
+        This method checks if the object is in the update queue
+        """
+        object_id_tuple = (object_id,)
+        in_queue = False
+        sql = "SELECT ID FROM REPOSITORY.DRS_OBJECT_UPDATE_STATUS " + \
+              "WHERE ID = :1"
+        cursor = self.db.cursor()
+        cursor.execute(sql, object_id_tuple)
+        row = cursor.fetchone()
+        if row:
+            in_queue = True
+        return in_queue

--- a/judaica.py
+++ b/judaica.py
@@ -70,7 +70,6 @@ if __name__ == "__main__":
     for file_id in file_ids:
         data.append(file_id)
         if len(data) % BATCH_SIZE == 0:
-            data = list(set(data))  # remove duplicates
             obj_tuple_list = drs_db.get_object_ids(data)
             # return a list of object_ids that are not in already_processed_ids
             object_ids = list(filter(lambda x: x not in already_processed_ids,
@@ -110,7 +109,6 @@ if __name__ == "__main__":
             bad_object_ids = []
 
     if data:
-        data = list(set(data))  # remove duplicates
         obj_tuple_list = drs_db.get_object_ids(data)
         # return a list of object_ids that are not in already_processed_ids
         object_ids = list(filter(lambda x: x not in already_processed_ids,

--- a/judaica.py
+++ b/judaica.py
@@ -22,6 +22,7 @@ def process_file(input_file):
 
     # remove whitespace characters like `\n` at the end of each line
     file_ids = [x.strip() for x in content]
+    file_ids = list(set(file_ids))  # deduplicate
     return file_ids
 
 

--- a/judaica.py
+++ b/judaica.py
@@ -21,7 +21,9 @@ def process_file(input_file):
         content = f.readlines()
 
     # remove whitespace characters like `\n` at the end of each line
-    file_ids = [x.strip() for x in content]
+    file_ids = [x.strip() for x in list(filter(lambda x:
+                                               (x.strip()).isdigit(),
+                                               content))]
     file_ids = list(set(file_ids))  # deduplicate
     return file_ids
 

--- a/judaica.py
+++ b/judaica.py
@@ -67,6 +67,7 @@ if __name__ == "__main__":
     for file_id in file_ids:
         data.append(file_id)
         if len(data) % BATCH_SIZE == 0:
+            data = list(set(data))  # remove duplicates
             obj_tuple_list = drs_db.get_object_ids(data)
             # return a list of object_ids that are not in already_processed_ids
             object_ids = list(filter(lambda x: x not in already_processed_ids,
@@ -106,6 +107,7 @@ if __name__ == "__main__":
             bad_object_ids = []
 
     if data:
+        data = list(set(data))  # remove duplicates
         obj_tuple_list = drs_db.get_object_ids(data)
         # return a list of object_ids that are not in already_processed_ids
         object_ids = list(filter(lambda x: x not in already_processed_ids,

--- a/ocflpaths.py
+++ b/ocflpaths.py
@@ -21,7 +21,9 @@ def process_file(input_file):
         content = f.readlines()
 
     # remove whitespace characters like `\n` at the end of each line
-    object_ids = [x.strip() for x in content]
+    object_ids = [x.strip() for x in list(filter(lambda x:
+                                                 (x.strip()).isdigit(),
+                                                 content))]
     object_ids = list(set(object_ids))  # deduplicate
     return object_ids
 

--- a/ocflpaths.py
+++ b/ocflpaths.py
@@ -92,6 +92,11 @@ if __name__ == "__main__":
                         "already processed, skipping...")
             skipped_count += 1
             continue
+        if drs_db.check_object_in_update_queue(object_id):
+            logger.error(f"ERROR: Object id {object_id} " +
+                        "is already in the update queue, skipping...")
+            skipped_count += 1
+            continue
         ocfl_path, storage_class = drs_db.get_descriptor_path(object_id)
         if ocfl_path:
             ocfl_paths = get_updated_paths(ocfl_path)

--- a/ocflpaths.py
+++ b/ocflpaths.py
@@ -94,7 +94,7 @@ if __name__ == "__main__":
             continue
         if drs_db.check_object_in_update_queue(object_id):
             logger.error(f"ERROR: Object id {object_id} " +
-                         "is already in the update queue, skipping...")
+                         "is STILL in the update queue, skipping...")
             skipped_count += 1
             continue
         ocfl_path, storage_class = drs_db.get_descriptor_path(object_id)

--- a/ocflpaths.py
+++ b/ocflpaths.py
@@ -22,6 +22,7 @@ def process_file(input_file):
 
     # remove whitespace characters like `\n` at the end of each line
     object_ids = [x.strip() for x in content]
+    object_ids = list(set(object_ids))  # deduplicate
     return object_ids
 
 

--- a/ocflpaths.py
+++ b/ocflpaths.py
@@ -94,7 +94,7 @@ if __name__ == "__main__":
             continue
         if drs_db.check_object_in_update_queue(object_id):
             logger.error(f"ERROR: Object id {object_id} " +
-                        "is already in the update queue, skipping...")
+                         "is already in the update queue, skipping...")
             skipped_count += 1
             continue
         ocfl_path, storage_class = drs_db.get_descriptor_path(object_id)

--- a/populate.py
+++ b/populate.py
@@ -1,0 +1,92 @@
+#!/usr/bin/python3
+
+import argparse
+import os
+import logging
+from dotenv import load_dotenv
+from drs2 import configure_logger
+import time
+
+load_dotenv()
+configure_logger()
+logger = logging.getLogger('drs2_judaica_update')
+
+
+def process_judaica(input_dir, output_dir):
+    """
+    This function processes all judaica files in the input dir &
+    writes files of object ids to the output dir.
+    """
+    DELAY_SECS = int(os.getenv("DELAY_SECS", 5))
+    judaica_path = os.getenv("JUDAICA_PATH", "/home/drsadm/bin/judaica.py")
+    files_processed = 0
+
+    for f in os.listdir(input_dir):
+        if f.endswith(".txt") or f.endswith(".csv"):
+            ocflpaths_filename = f"ocflpath_input_{files_processed}.txt"
+            input_file = os.path.join(input_dir, f)
+            output_file = os.path.join(output_dir, ocflpaths_filename)
+            logger.info(f"Processing {input_file} for judaica...")
+            os.system(f"{judaica_path} -i {input_file} -o {output_file}")
+            files_processed = files_processed + 1
+            logger.info(f"Processing {input_file} for judaica complete")
+            time.sleep(DELAY_SECS)
+
+    return files_processed
+
+
+def process_ocflpath(input_dir, output_dir):
+    """
+    This function processes all files of object ids in the input dir &
+    writes files of ocfl paths to the output dir.
+    """
+    DELAY_SECS = int(os.getenv("DELAY_SECS", 5))
+    ocflpaths_path = os.getenv("OCFLPATHS_PATH", "/home/drsadm/bin/ocflpaths.py")
+    files_processed = 0
+
+    for f in os.listdir(input_dir):
+        if f.startswith("ocflpath_input_") and f.endswith(".txt"):
+            ocflpaths_filename = f"output_{files_processed}.txt"
+            input_file = os.path.join(input_dir, f)
+            output_file = os.path.join(output_dir, ocflpaths_filename)
+            logger.info(f"Processing ocfl paths from {input_file}...")
+            os.system(f"{ocflpaths_path} -i {input_file} -o {output_file}")
+            files_processed = files_processed + 1
+            logger.info(f"Processing ocfl paths from {input_file} completed")
+            time.sleep(DELAY_SECS)
+
+    return files_processed
+
+
+if __name__ == "__main__":
+    BATCH_SIZE = int(os.getenv("BATCH_SIZE", 1000))
+    LOG_FILE = os.getenv("LOGFILE_PATH", "./logs/drs_judaica.log")
+
+    # Create an ArgumentParser object
+    parser = argparse.ArgumentParser(description="Process a directory  and \
+                                     generate object id files & ocfl paths.")
+
+    # Add command-line arguments
+    parser.add_argument("-i", "--input_dir",
+                        required=True,
+                        help="Path to the input directory")
+    parser.add_argument("-o", "--output_dir",
+                        required=True,
+                        help="Path to the judaica output dir/ ocfl input dir")
+    parser.add_argument("-x", "--final_dir",
+                        required=True,
+                        help="Path to the final output dir of ocfl paths")
+
+    # Parse the command-line arguments
+    args = parser.parse_args()
+
+    # Step 1: Call the process_file function
+    logger.info(f"Processing judaica files in {args.input_dir}")
+    judaica_files = process_judaica(args.input_dir, args.output_dir)
+    logger.info(f"Processed {judaica_files} judaica files")
+    time.sleep(10)
+    # Step 2: Call the process_ocfl function
+    logger.info("Now processing ocfl paths for all judaica files")
+    ocflpaths_files = process_ocflpath(args.output_dir, args.final_dir)
+    logger.info(f"Processed {ocflpaths_files} ocflpaths files")
+    logger.info("Processing completed")

--- a/populate.py
+++ b/populate.py
@@ -18,7 +18,8 @@ def process_judaica(input_dir, output_dir):
     writes files of object ids to the output dir.
     """
     DELAY_SECS = int(os.getenv("DELAY_SECS", 5))
-    judaica_path = os.getenv("JUDAICA_PATH", "/home/drsadm/bin/judaica.py")
+    judaica_path = os.getenv("JUDAICA_PATH",
+                             "/home/drsadm/bin/judaica.py")
     files_processed = 0
 
     for f in os.listdir(input_dir):
@@ -41,7 +42,8 @@ def process_ocflpath(input_dir, output_dir):
     writes files of ocfl paths to the output dir.
     """
     DELAY_SECS = int(os.getenv("DELAY_SECS", 5))
-    ocflpaths_path = os.getenv("OCFLPATHS_PATH", "/home/drsadm/bin/ocflpaths.py")
+    ocflpaths_path = os.getenv("OCFLPATHS_PATH",
+                               "/home/drsadm/bin/ocflpaths.py")
     files_processed = 0
 
     for f in os.listdir(input_dir):


### PR DESCRIPTION
**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/LIBDRS-9361



# What does this Pull Request do?
populates the queue. this should also prevent processing duplicate file/object ids and it restores logging to disk.

# How should this be tested?

1. pull down branch
2. create  or copy`.env in` base dir
3. mkdir `./io/judaica`
4. put input files in .`/io/judaica`
5. `mkdir ./io/ocfl-input ./io/ocfl-paths`
6. `./scripts/local-image-build.sh`
7. `./scripts/local-image-run.sh`
8. `populate.py -i  /app/io/judaica -o /app/io/ocfl-input -x /app/io/ocfl-paths`
9. you should see the final list of files containing ocfl paths in /app/io/ocfl-paths

the output should look similar to this:

```
drsadm@dbb99662861f:/app$ populate.py -i  /app/io/judaica -o /app/io/ocfl -x /app/io/final
2024-03-02 02:11:06,314 - drs2_judaica_update - INFO - [populate.py:<module>:84] - Processing judaica files in /app/io/judaica
2024-03-02 02:11:06,318 - drs2_judaica_update - INFO - [populate.py:process_judaica:29] - Processing /app/io/judaica/input-ctv.txt for judaica...
2024-03-02 02:11:06,888 - drs2_judaica_update - INFO - [judaica.py:<module>:61] - Processing 1 file ids in /app/io/judaica/input-ctv.txt
2024-03-02 02:11:06,966 - drs2_judaica_update - INFO - [judaica.py:<module>:137] - Object id 400330509 updated successfully
2024-03-02 02:11:06,998 - drs2_judaica_update - INFO - [judaica.py:<module>:156] - Completed processing 1 file ids
2024-03-02 02:11:06,999 - drs2_judaica_update - INFO - [judaica.py:<module>:157] - Updated 1 object ids
2024-03-02 02:11:07,000 - drs2_judaica_update - INFO - [judaica.py:<module>:158] - Failed to update 0 object ids
2024-03-02 02:11:07,021 - drs2_judaica_update - INFO - [populate.py:process_judaica:32] - Processing /app/io/judaica/input-ctv.txt for judaica complete
2024-03-02 02:11:12,027 - drs2_judaica_update - INFO - [populate.py:<module>:86] - Processed 1 judaica files
2024-03-02 02:11:22,040 - drs2_judaica_update - INFO - [populate.py:<module>:89] - Now processing ocfl paths for all judaica files
2024-03-02 02:11:22,045 - drs2_judaica_update - INFO - [populate.py:process_ocflpath:52] - Processing ocfl paths from /app/io/ocfl/ocflpath_input_0.txt...
2024-03-02 02:11:22,529 - drs2_judaica_update - INFO - [ocflpaths.py:<module>:79] - Processing 1 object ids in /app/io/ocfl/ocflpath_input_0.txt
2024-03-02 02:11:22,598 - drs2_judaica_update - INFO - [ocflpaths.py:<module>:116] - Completed processing 1 object ids
2024-03-02 02:11:22,599 - drs2_judaica_update - INFO - [ocflpaths.py:<module>:117] - Updated 1 object ids
2024-03-02 02:11:22,600 - drs2_judaica_update - INFO - [ocflpaths.py:<module>:118] - Failed to update 0 object ids
2024-03-02 02:11:22,623 - drs2_judaica_update - INFO - [populate.py:process_ocflpath:55] - Processing ocfl paths from /app/io/ocfl/ocflpath_input_0.txt completed
2024-03-02 02:11:27,629 - drs2_judaica_update - INFO - [populate.py:<module>:91] - Processed 1 ocflpaths files
2024-03-02 02:11:27,631 - drs2_judaica_update - INFO - [populate.py:<module>:92] - Processing completed
```


# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n
- integration tests? n

# Interested parties
Tag (@ mention) interested parties: @awoods 
