### PR TITLE
Treat objects still being updated as errors. Log skipped count.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ Currently contains 1 script that:
   in the input file.
   Failures will be written to `errors.txt`.
 
+## Running the controller script to invoke the other two scripts
+- For usage
+  - `populate.py`
+- Set up directory structure (example)
+  - `mkdir ./io ./io/judaica ./io/ocfl-input ./io/ocfl-paths`
+  - Place input file(s) containing file IDs in `./io/judaica`
+- Run according to usage
+  - `populate.py -i /app/io/judaica -o /app/io/ocfl-input -x /app/io/ocfl-paths`
+  - This will call `judaica.py` for each file in `io/judaica`. After the output 
+  has been created in `io/ocfl-input`, it will pass each output file to `ocflpaths.py`. 
+  The final output of CSV files containg S3 paths will be written to `io/ocfl-paths`
+  There is a configurable delay between calls, which defaults to 5 seconds.
+
 ## Notes
 - The script is set up to overwrite a given output file on subsequent runs.
   

--- a/judaica.py
+++ b/judaica.py
@@ -158,4 +158,5 @@ if __name__ == "__main__":
 
     logger.info(f"Completed processing {len(file_ids)} file ids")
     logger.info(f"Updated {updated_count} object ids")
+    logger.info(f"Skipped {skipped_count} object ids")
     logger.info(f"Failed to update {error_count} object ids")

--- a/ocflpaths.py
+++ b/ocflpaths.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
         if drs_db.check_object_in_update_queue(object_id):
             logger.error(f"ERROR: Object id {object_id} " +
                          "is STILL in the update queue, skipping...")
-            skipped_count += 1
+            error_count += 1
             continue
         ocfl_path, storage_class = drs_db.get_descriptor_path(object_id)
         if ocfl_path:
@@ -123,4 +123,5 @@ if __name__ == "__main__":
 
     logger.info(f"Completed processing {len(object_ids)} object ids")
     logger.info(f"Updated {updated_count} object ids")
+    logger.info(f"Skipped {skipped_count} object ids")
     logger.info(f"Failed to update {error_count} object ids")


### PR DESCRIPTION
**Treat objects still being updated as errors. Log skipped count. Update README.**
* * *

**JIRA Ticket**: [LIBDRS-9361](https://at-harvard.atlassian.net/browse/LIBDRS-9361)

# What does this Pull Request do?
Treats object IDs still in the update table as errors when writing out S3 paths.
Logs the total skipped count at the end of scripts.
Update README with example to run `populate.py`.

# Test coverage
Yes/No: No

# Interested parties
@cgoines 


[LIBDRS-9361]: https://at-harvard.atlassian.net/browse/LIBDRS-9361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ