### PR TITLE
Use descriptor disposition from database.

### DIFF
--- a/ocflpaths.py
+++ b/ocflpaths.py
@@ -28,7 +28,7 @@ def process_file(input_file):
     return object_ids
 
 
-def get_updated_paths(descriptor_path):
+def get_updated_paths(descriptor_path, descriptor_storage_class):
     STORAGE_CLASS = "RE"
     INVENTORY_JSON = "inventory.json"
     INVENTORY_JSON_SHA512 = "inventory.json.sha512"
@@ -42,7 +42,7 @@ def get_updated_paths(descriptor_path):
                          ", " + STORAGE_CLASS)
     updated_paths.append(descriptor_root + INVENTORY_JSON_SHA512 +
                          ", " + STORAGE_CLASS)
-    updated_paths.append(descriptor_path + ", " + STORAGE_CLASS)
+    updated_paths.append(descriptor_path + ", " + descriptor_storage_class)
     return updated_paths
 
 
@@ -99,7 +99,7 @@ if __name__ == "__main__":
             continue
         ocfl_path, storage_class = drs_db.get_descriptor_path(object_id)
         if ocfl_path:
-            ocfl_paths = get_updated_paths(ocfl_path)
+            ocfl_paths = get_updated_paths(ocfl_path, storage_class)
             for path in ocfl_paths:
                 output.write(f"{path}\n")
             updated_count += 1


### PR DESCRIPTION
**Use descriptor disposition from database.**
* * *

**JIRA Ticket**: [LIBDRS-9371](https://at-harvard.atlassian.net/browse/LIBDRS-9371)

# What does this Pull Request do?
Uses the descriptor disposition stored in the database to write the the `ocflpaths.py` output file.

# How should this be tested?
* Pull branch
* Build image: `./scripts/local-image-build.sh`
* Start up container: `docker run --rm --name my-judaica-update --mount type=bind,source=${PWD},target=/app --env-file .env -it drs2-judaica-update:latest`
* Create input file: `vi object_ids.txt`
  * Add 1 ID: `400287365`
* Run script: `ocflpaths.py -i object_ids.txt -o ocflpaths.txt` 
* Verify that the disposition for the descriptor is `DE`: `less ocflpaths.txt`

# Test coverage
Yes/No: No

# Interested parties
@cgoines 

[LIBDRS-9371]: https://at-harvard.atlassian.net/browse/LIBDRS-9371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ