### PR TITLE
Reduce sleep delay between output of ocfl path files.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,4 +20,5 @@ DB_PASSWORD=
 # paths for judaica.py and ocflpaths.py 
 JUDAICA_PATH=/home/drsadm/bin/judaica.py
 OCFLPATHS_PATH=/home/drsadm/bin/ocflpaths.py
-DELAY_SECS=5
+DELAY_SECS_JUDAICA=360
+DELAY_SECS_OCFLPATHS=60

--- a/populate.py
+++ b/populate.py
@@ -17,7 +17,7 @@ def process_judaica(input_dir, output_dir):
     This function processes all judaica files in the input dir &
     writes files of object ids to the output dir.
     """
-    DELAY_SECS = int(os.getenv("DELAY_SECS", 5))
+    DELAY_SECS_JUDAICA = int(os.getenv("DELAY_SECS_JUDAICA", 5))
     judaica_path = os.getenv("JUDAICA_PATH",
                              "/home/drsadm/bin/judaica.py")
     files_processed = 0
@@ -31,7 +31,7 @@ def process_judaica(input_dir, output_dir):
             os.system(f"{judaica_path} -i {input_file} -o {output_file}")
             files_processed = files_processed + 1
             logger.info(f"Processing {input_file} for judaica complete")
-            time.sleep(DELAY_SECS)
+            time.sleep(DELAY_SECS_JUDAICA)
 
     return files_processed
 
@@ -41,7 +41,7 @@ def process_ocflpath(input_dir, output_dir):
     This function processes all files of object ids in the input dir &
     writes files of ocfl paths to the output dir.
     """
-    DELAY_SECS = int(os.getenv("DELAY_SECS", 5))
+    DELAY_SECS_OCFLPATHS = int(os.getenv("DELAY_SECS_OCFLPATHS", 5))
     ocflpaths_path = os.getenv("OCFLPATHS_PATH",
                                "/home/drsadm/bin/ocflpaths.py")
     files_processed = 0
@@ -56,7 +56,7 @@ def process_ocflpath(input_dir, output_dir):
             files_processed = files_processed + 1
             logger.info(f"Processing ocfl paths from {input_file} completed")
             # Sleep briefly to avoid overloading the database
-            time.sleep(60)
+            time.sleep(DELAY_SECS_OCFLPATHS)
 
     return files_processed
 

--- a/populate.py
+++ b/populate.py
@@ -55,7 +55,8 @@ def process_ocflpath(input_dir, output_dir):
             os.system(f"{ocflpaths_path} -i {input_file} -o {output_file}")
             files_processed = files_processed + 1
             logger.info(f"Processing ocfl paths from {input_file} completed")
-            time.sleep(DELAY_SECS)
+            # Sleep briefly to avoid overloading the database
+            time.sleep(60)
 
     return files_processed
 


### PR DESCRIPTION
**Reduce sleep delay between output of ocfl path files.**
* * *

**JIRA Ticket**: none

# What does this Pull Request do?
Reduce the delay between creation of output files by `ocflpaths.py`. There needs to be a long delay between calls to `judaica.py`, because there is a long lag time until DRS completes updating the objects. For `ocflpaths.py` there doesn't need to be such a long wait, because it is read-only and there are no other processes that need to complete before it can move to the next batch of IDs. The 60 second delay is used to keep the database from being overloaded. This will greatly reduce the time for creating the final OCFL path output, because instead of pausing for 2-3 hours before each batch, it only waits 60 seconds.

# Test coverage
Yes/No: N/A

# Interested parties
@cgoines 
